### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/programs/raffler_anchor/src/security.rs
+++ b/programs/raffler_anchor/src/security.rs
@@ -1,5 +1,6 @@
 use solana_security_txt::security_txt;
 
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Solana Raffler",
     project_url: "https://github.com/Flawm/solana_raffler/",


### PR DESCRIPTION
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.
